### PR TITLE
fix: resolve sessionStorage is not defined in some platforms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,10 @@ export const updateStorage = (strategy: PersistStrategy, store: Store) => {
 
 export default ({ options, store }: PiniaPluginContext): void => {
   if (options.persist?.enabled) {
-    const defaultStrat: PersistStrategy[] = [{
-      key: store.$id,
-      storage: sessionStorage,
-    }]
 
-    const strategies = options.persist?.strategies?.length ? options.persist?.strategies : defaultStrat
+    const strategies = options.persist?.strategies?.length
+      ? options.persist?.strategies
+      : [{ key: store.$id, storage: sessionStorage }]
 
     strategies.forEach((strategy) => {
       const storage = strategy.storage || sessionStorage


### PR DESCRIPTION
In some platforms, sessionStorage does not exist

<img width="797" alt="image" src="https://user-images.githubusercontent.com/26431026/168483057-a2088524-1c79-43e5-b9ec-6fa5b6a2180d.png">

<img width="452" alt="image" src="https://user-images.githubusercontent.com/26431026/168483074-b7936e83-5889-4451-97fd-61e49eb24405.png">
