### PR TITLE
Add the documented "type": "module" flag line to package.json,

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "require": "./dist/pinia-persist.umd.js"
     }
   },
+  "type": "module",
   "types": "./dist",
   "devDependencies": {
     "@babel/types": "^7.17.0",


### PR DESCRIPTION
 so that ESM module files (.mjs) can successfully import this package, 
while keeping the .js extension. This feature was added to Nodejs at v12.0.0.
Documented to present [here](https://nodejs.org/api/esm.html#enabling), 
widely needed and used. 

